### PR TITLE
add `package.json` file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "yields-traverse",
+  "version": "0.1.1",
+  "description": "low level traverse function, inspired by $.dir.",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/yields/traverse.git"
+  },
+  "keywords": [
+    "traverse",
+    "dir"
+  ],
+  "author": "Amir Abu Shareb <yields@icloud.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/yields/traverse/issues"
+  },
+  "homepage": "https://github.com/yields/traverse",
+  "dependencies": {
+    "matches-selector": "*"
+  }
+}


### PR DESCRIPTION
For browserify support.

I've already published `yields-traverse` to npm, and added `yields` as an owner to the npm package. So nothing _really_ needed to be done.

:beers: 