### PR TITLE
support elements as a selector

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@
 
 ## API
 
-#### traverse(property, element, [selector, [length]])
+#### traverse(property, element, [selector|element, [length]])
 
 Traverse using the given `property` on `element` getting elements
 that match the given `selector` until `len` is reached.
@@ -31,6 +31,10 @@ traverse('parentNode', el, 'p', Infinity);
 // getting a single `<p>` sibling
 
 traverse('nextSibling', el, 'p');
+
+// traversing to an element
+
+traverse('parentNode', el, document.body);
 ```
 
 ## License

--- a/component.json
+++ b/component.json
@@ -11,7 +11,7 @@
     "component/matches-selector": "*"
   },
   "development": {
-    "visionmedia/mocha": "*",
+    "visionmedia/mocha": "1.21.5",
     "component/assert": "*"
   }
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var matches = require('matches-selector');
  *
  * @param {String} type
  * @param {Element} el
- * @param {String} selector
+ * @param {String|Element} selector
  * @param {Number} len
  * @return {Array}
  * @api public
@@ -23,10 +23,14 @@ module.exports = function(type, el, selector, len){
 
   if (!el) return ret;
 
+  // check if `selector` is a DOM node
+  var isElement = selector && selector.nodeName;
+
   do {
     if (n == ret.length) break;
     if (1 != el.nodeType) continue;
-    if (matches(el, selector)) ret.push(el);
+    if (isElement) el == selector && ret.push(el);
+    else if (matches(el, selector)) ret.push(el);
     if (!selector) ret.push(el);
   } while (el = el[type]);
 

--- a/test/test.js
+++ b/test/test.js
@@ -67,7 +67,14 @@ describe('traverse', function(){
     })
   })
 
-
+  describe('traverse("parentNode", el, document.body)', function() {
+    it('should also work with elements', function() {
+      var el = tests[0].querySelector('.one');
+      var els = traverse('parentNode', el, document.body);
+      assert(document.body == els[0]);
+      assert(1 == els.length);
+    })
+  })
 
   function assertall(type, els){
     for (var i = 0; i < els.length; ++i) {


### PR DESCRIPTION
This PR adds support for traversing to an element. Example:

``` js
traverse('parentNode', el, document.body);
```
